### PR TITLE
Improve Shooter

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -83,6 +83,6 @@ public class Robot
     climber.setDefaultCommand(new ClimberStop(this));
     drivetrain.setDefaultCommand(new Drive(this));
     conveyor.setDefaultCommand(new ConveyorStop(this));
-    shooter.setDefaultCommand(new ShooterStop(this));
+    shooter.setDefaultCommand(new ShooterSpin(this));
   }
 }

--- a/src/main/java/frc/robot/controls/Operator.java
+++ b/src/main/java/frc/robot/controls/Operator.java
@@ -40,9 +40,8 @@ public class Operator
     private JoystickButton climberExtend;
     private JoystickButton climberRetract;
 
-    private JoystickButton shooterSpin;
+	// PORTS //
 
-	// CONSTANTS //
     public static final int DUALSHOCK = 2;
 
     public static final int INTAKE_IN = 8;
@@ -58,7 +57,8 @@ public class Operator
     public static final int CLIMBER_EXTEND = 3;
     public static final int CLIMBER_RETRACT = 2;
 
-    public static final int SHOOTER_SPIN = 9;
+    // CONSTANTS //
+    public static final double SHOOTER_DEADZONE = 0.1;
 
 
     public Operator(Robot robot)
@@ -80,8 +80,6 @@ public class Operator
         climberExtend = new JoystickButton(dualshock, CLIMBER_EXTEND);
         climberRetract = new JoystickButton(dualshock, CLIMBER_RETRACT);
 
-        shooterSpin = new JoystickButton(dualshock, SHOOTER_SPIN);
-
         // bind buttons to commands
         intakeIn.whenHeld(new IntakeSpin(robot));
         intakeOut.whenHeld(new IntakeReverse(robot));
@@ -95,14 +93,22 @@ public class Operator
         climberUnwind.whenHeld(new ClimberUnwind(robot));
         climberExtend.whenHeld(new ClimberExtend(robot));
         climberRetract.whenHeld(new ClimberRetract(robot));
-
-        shooterSpin.whenHeld(new ShooterSpin(robot));
     }
        // METHODS
 
     // Add methods here which return values for various robot controls by reading the controllers.
+
+    /* Authors: Jason Wang & Lucas Jacobs*
+    * Desc:
+    * Returns the power given to the shooter by reading the left
+    * joystick of the controller*/
+
     public double getShooterPower(){
-        return dualshock.getThrottle();
+        double power = dualshock.getThrottle();
+
+        if (Math.abs(power) < SHOOTER_DEADZONE) power = 0;
+
+        return power;
     }
 }
 

--- a/src/main/java/frc/robot/controls/Operator.java
+++ b/src/main/java/frc/robot/controls/Operator.java
@@ -104,7 +104,7 @@ public class Operator
     * joystick of the controller*/
 
     public double getShooterPower(){
-        double power = dualshock.getThrottle();
+        double power = -dualshock.getY();
 
         if (Math.abs(power) < SHOOTER_DEADZONE) power = 0;
 


### PR DESCRIPTION
- Remove the redundant ShooterSpin button, since ShooterSpin is already the default command (**Edit: This PR will change ShooterSpin to be the default command**)
- Add deadzone to shooter joystick