### PR TITLE
Make Default Commands false

### DIFF
--- a/src/main/java/frc/robot/commands/climber/ClimberStop.java
+++ b/src/main/java/frc/robot/commands/climber/ClimberStop.java
@@ -40,6 +40,6 @@ public class ClimberStop extends CommandBase{
   @Override
   public boolean isFinished()
   {
-    return true;
+    return false;
   }
 }

--- a/src/main/java/frc/robot/commands/conveyor/ConveyorStop.java
+++ b/src/main/java/frc/robot/commands/conveyor/ConveyorStop.java
@@ -60,6 +60,6 @@ public class ConveyorStop extends CommandBase
   @Override
   public boolean isFinished()
   {
-    return true;
+    return false;
   }
 }


### PR DESCRIPTION
Default commands must be false (i.e. not end) for the code to run on the robot
- Changed true to false in isFinished() for ClimberStop and ConveyorStop