### PR TITLE
Remove vision from being required

### DIFF
--- a/src/main/java/frc/robot/commands/auto/AutoShoot.java
+++ b/src/main/java/frc/robot/commands/auto/AutoShoot.java
@@ -40,7 +40,7 @@ public class AutoShoot extends CommandBase
     finished = false;
 
     // subsystems that this command requires
-    addRequirements(robot.vision, robot.drivetrain, robot.shooter, robot.conveyor);
+    addRequirements(robot.drivetrain, robot.shooter, robot.conveyor);
   }
 
   // METHODS //

--- a/src/main/java/frc/robot/commands/vision/VisionAim.java
+++ b/src/main/java/frc/robot/commands/vision/VisionAim.java
@@ -29,7 +29,7 @@ public class VisionAim extends CommandBase
     this.robot = robot;
 
     // subsystems that this command requires
-    addRequirements(robot.vision, robot.drivetrain, robot.shooter);
+    addRequirements(robot.drivetrain, robot.shooter);
   }
 
   // METHODS //


### PR DESCRIPTION
- Removes vision from being required by Auto Shoot and VisionAim. Theses methods are just reading and not writing, so it doesn't matter if they access vision at the same time as something else