### PR TITLE
Give control to Operator

### DIFF
--- a/src/main/java/frc/robot/commands/auto/AutoHubShoot.java
+++ b/src/main/java/frc/robot/commands/auto/AutoHubShoot.java
@@ -11,14 +11,16 @@
 
 package frc.robot.commands.auto;
 
+import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.Robot;
+import frc.robot.commands.shooter.ShooterSpin;
 
 public class AutoHubShoot extends SequentialCommandGroup {
     public AutoHubShoot(Robot robot) {
         super(
-            new AutoDrive(robot, -.8, 0, 1.1), // drive backwards
-            new AutoShoot(robot, .35, 1) //shoot
+            new AutoDrive(robot, -.8, 0, 1), // drive backwards
+            new AutoShoot(robot, .365, 1.7) //shoot
         );
     }
 }

--- a/src/main/java/frc/robot/commands/auto/AutoVisionShoot.java
+++ b/src/main/java/frc/robot/commands/auto/AutoVisionShoot.java
@@ -20,22 +20,22 @@ public class AutoVisionShoot extends CommandBase
   // VARIABLES //
 
   private Robot robot;
-  private Timer timer;
-  private double timeToShot;
-  private final static double CONVEYOR_SPIN_TIME = .6;
+  //private Timer timer;
+  //private double timeToShot;
+  //private final static double CONVEYOR_SPIN_TIME = .6;
 
   // CONSTANTS //
 
   // CONSTRUCTOR //
 
-  public AutoVisionShoot(Robot robot, double timeToShot)
+  public AutoVisionShoot(Robot robot/*, double timeToShot*/)
   {
     this.robot = robot;
-    this.timeToShot = timeToShot;
-    timer = new Timer();
+    //this.timeToShot = timeToShot;
+    //timer = new Timer();
 
     // subsystems that this command requires
-    addRequirements(robot.shooter, robot.conveyor);
+    addRequirements(robot.shooter/*, robot.conveyor*/);
   }
 
   // METHODS //
@@ -45,9 +45,9 @@ public class AutoVisionShoot extends CommandBase
   public void initialize()
   {
     robot.vision.enableShootingLight();
-
-    timer.start();
-    timer.reset();
+    robot.shooter.setAutoShooting(true);
+    //timer.start();
+    //timer.reset();
 
     SmartDashboard.putString("Robot Mode:", "Auto Shoot");
   }
@@ -57,7 +57,12 @@ public class AutoVisionShoot extends CommandBase
   public void execute()
   {
     //Spin shooter at auto speed
-    while (timer.get() < timeToShot) {
+    double autoSpeed = robot.vision.autoShooterSpeed();
+    robot.shooter.spin(autoSpeed);
+
+    robot.vision.calcAlign(robot.drivetrain.gyroAngle());
+
+    /*while (timer.get() < timeToShot) {
       double autoSpeed = robot.vision.autoShooterSpeed();
       robot.shooter.spin(autoSpeed);
     }
@@ -76,7 +81,7 @@ public class AutoVisionShoot extends CommandBase
       } else {
         break;
       }
-    }
+    }*/
   }
 
   // Called once the command ends or is interrupted.
@@ -87,12 +92,14 @@ public class AutoVisionShoot extends CommandBase
 
     robot.shooter.stop();
     robot.conveyor.stop();
+
+    robot.shooter.setAutoShooting(false);
   }
 
   // Returns true when the command should end.
   @Override
   public boolean isFinished()
   {
-    return true;
+    return false;
   }
 }

--- a/src/main/java/frc/robot/commands/auto/AutoWallShoot.java
+++ b/src/main/java/frc/robot/commands/auto/AutoWallShoot.java
@@ -11,11 +11,12 @@ package frc.robot.commands.auto;
 
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import frc.robot.Robot;
+import frc.robot.commands.shooter.ShooterSpin;
 
 public class AutoWallShoot extends ParallelCommandGroup {
     public AutoWallShoot(Robot robot) {
         super(
-            new AutoShoot(robot, .37, 1) //shoot
+            new ShooterSpin(robot, .37) //shoot
         );
     }
 }

--- a/src/main/java/frc/robot/commands/conveyor/ConveyorFeed.java
+++ b/src/main/java/frc/robot/commands/conveyor/ConveyorFeed.java
@@ -46,7 +46,15 @@ public class ConveyorFeed extends CommandBase
   @Override
   public void execute()
   {
-    robot.conveyor.feed();
+    if (robot.shooter.isAutoShooting()) {
+      robot.vision.calcAlign(robot.drivetrain.gyroAngle());
+
+      if (robot.vision.isAligned()) {
+        robot.conveyor.feed();
+      }
+    } else {
+      robot.conveyor.feed();
+    }
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/shooter/ShooterSpin.java
+++ b/src/main/java/frc/robot/commands/shooter/ShooterSpin.java
@@ -45,6 +45,6 @@ public class ShooterSpin extends CommandBase{
   @Override
   public boolean isFinished()
   {
-    return true;
+    return false;
   }
 }

--- a/src/main/java/frc/robot/controls/Operator.java
+++ b/src/main/java/frc/robot/controls/Operator.java
@@ -125,11 +125,11 @@ public class Operator
         climberExtend.whileHeld(new ClimberExtend(robot));
         climberRetract.whileHeld(new ClimberRetract(robot));
       
-        autoShoot.whileHeld(new AutoVisionShoot(robot, 1));
+        autoShoot.whileHeld(new AutoVisionShoot(robot));
         
         shooterHub.whenPressed(new AutoHubShoot(robot));
         shooterSpin.whileHeld(new ShooterSpin(robot, SHOOTER_SPEED_SPIN));
-        shooterWall.whenPressed(new AutoWallShoot(robot));
+        shooterWall.whenHeld(new AutoWallShoot(robot));
         shooterReverse.whileHeld(new ShooterSpin(robot, SHOOTER_SPEED_REVERSE));
     }
        // METHODS

--- a/src/main/java/frc/robot/pipelines/WaterlooSettings.java
+++ b/src/main/java/frc/robot/pipelines/WaterlooSettings.java
@@ -34,7 +34,7 @@ public class WaterlooSettings extends PipelineSettings {
 		filterContoursMaxWidth = 1000.0;
 		filterContoursMinHeight = 0.0;
 		filterContoursMaxHeight = 100.0;
-		filterContoursSolidity[0] = 10;
+		filterContoursSolidity[0] = 0;
 		filterContoursSolidity[1] = 100;
 		filterContoursMaxVertices = 1000000.0;
 		filterContoursMinVertices = 0.0;

--- a/src/main/java/frc/robot/subsystems/Conveyor.java
+++ b/src/main/java/frc/robot/subsystems/Conveyor.java
@@ -21,9 +21,9 @@ public class Conveyor extends SubsystemBase
   // CONSTANTS //
   final static int CONVEYOR_PORT = 3;
 
-  final static double CONVEYOR_SPEED = 0.4;
+  final static double CONVEYOR_SPEED = 0.3;
   final static double SLOW_CONVEYOR_SPEED = 0.2;
-  final static double CONVEYOR_REVERSE_SPEED = -0.3;
+  final static double CONVEYOR_REVERSE_SPEED = -0.2;
 
   // CONSTRUCTOR //
 

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -18,10 +18,16 @@ public class Shooter extends SubsystemBase
  public static final int SHOOTER_MOTOR = 2;
  // Constants //
  public static final double DEFAULT_SHOOTER_SPEED= 0.5;
+
+ // VARIABLES // 
+ private boolean autoShooting;
+
   public Shooter()
   {
     // instantiate hardware
     motor = new PWMTalonSRX(SHOOTER_MOTOR);
+
+    autoShooting = false;
   }
   // METHODS //
   // spins the motor for the shooter
@@ -35,6 +41,14 @@ public class Shooter extends SubsystemBase
     motor.set(0);
   }//updates the speed for the motor to accomodate the distance from the target
   // this updated speed would be the speed the algorithm calculates in vision.java
+
+  public boolean isAutoShooting() {
+    return autoShooting;
+  }
+
+  public void setAutoShooting(boolean autoShooting) {
+    this.autoShooting = autoShooting;
+  }
 }
 
 //things to go in vision:

--- a/src/main/java/frc/robot/subsystems/Vision.java
+++ b/src/main/java/frc/robot/subsystems/Vision.java
@@ -37,8 +37,6 @@ public class Vision extends SubsystemBase {
   private final static int LIGHT_PORT = 2;
 
   // CONSTANTS //
-  final static int CAM_HEIGHT = 480;
-  final static int CAM_WIDTH = 640;
   final static int IMG_HEIGHT = 120;
   final static int IMG_WIDTH = 160;
   final static int FPS = 30;
@@ -180,6 +178,7 @@ public class Vision extends SubsystemBase {
         for (int i = 0; i < pipeline.filterContoursOutput().size(); i++) {
           Rect contour = Imgproc.boundingRect(pipeline.filterContoursOutput().get(i));
 
+          if (contour.y > IMG_WIDTH/2) continue; // Skip rectangles too low on the screen
           targets.add(contour);
 
           if (contour.area() > biggest.area()) biggest = contour;


### PR DESCRIPTION
- Give control to the Operator when using AutoVisionShoot and WallShoot. This means that we don't have to add any extra code to deal with two balls, since a human will deal with it all
- Make it so that if the drive team is trying to auto shoot, the conveyor will only spin if the robot is aligned. This prevents misses caused by a poor line of sight to the robot

- Change Hub Shoot variables so that the ball goes in 
- Decrease conveyor speed
- Adjust competition vision pipeline
- Make vision ignore targets that are in the bottom half of the screen. This hopefully prevents the vision from targeting the screen at the competition